### PR TITLE
[experimental] Add installationComplete() function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export function withUiHook(handler: Handler) {
 
 			if(output instanceof InstallationCompleteSignal) {
 				res.setHeader('x-vercel-integration-installation-complete', '1')
-				return send(res, 200, renderAST(null))
+				return send(res, 200, 'Installation Complete')
 			}
 
 			if (output.isAST === true) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import VercelClient from './vercel-client';
 export interface HandlerOptions {
 	payload: UiHookPayload;
 	vercelClient: VercelClient;
+	installationComplete?: () => void;
 	// to be removed in future versions
 	zeitClient: VercelClient;
 }
@@ -32,6 +33,7 @@ export interface UiHookPayload {
 		name: string;
 		description: string;
 	} | null;
+	installing?: boolean;
 }
 
 export interface FetchOptions extends RequestInit {


### PR DESCRIPTION
This PR adds a `installationComplete()` function to the properties passed to the handler:
```js
withUiHook(async ({ installationComplete }) => {
  // check if the integration is going through the "installation flow"
  if (installationComplete) {
    // do something else

    // signal the completion of the integration installation:
    return installationComplete()
  }
})
```

When the UI hook is not invoked in the installation flow, `installationComplete` is `undefined`.

Remark: this PR doesn't add the property to the README because it's experimental.